### PR TITLE
Fix an error with resize behavior

### DIFF
--- a/jquery.fluidbox.js
+++ b/jquery.fluidbox.js
@@ -206,7 +206,7 @@
 				funcCalc();
 
 				// Reposition Fluidbox, but only if one is found to be open
-				var $activeFb = $('a[data-fluidbox].fluidbox-opened');
+				var $activeFb = $('a.fluidbox.fluidbox-opened');
 				if($activeFb.length > 0) funcPositionFb($activeFb);
 			}
 


### PR DESCRIPTION
was bound to a[data-fluidbox] which I believe is either vestigial or
conventional to original author’s code. Instead specify a selector that
matches explicit class assignments in this module, so it should work
more universally.
