### PR TITLE
Updating bower.json file to be able to use this package correctly.

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -4,7 +4,6 @@
     "homepage": "https://github.com/terrymun/Fluidbox",
     "main": [
         "./jquery.fluidbox.js",
-        "./jquery.fluidbox.min.js",
         "./css/fluidbox.css"
     ],
     "authors": [
@@ -18,7 +17,6 @@
         "type": "git",
         "url": "https://github.com/terrymun/Fluidbox/"
     },
-    "main": "jquery.fluidbox.js",
     "keywords": [
         "fluidbox",
         "lightbox"


### PR DESCRIPTION
The `bower.json` file had to `main` field, which caused troubles if one wanted to use this package by automatically injecting files (it wouldn't inject the css, because only the last `main` field was taken into account).