### PR TITLE
close fluidbox on scroll event

### DIFF
--- a/src/js/jquery.fluidbox.js
+++ b/src/js/jquery.fluidbox.js
@@ -560,6 +560,11 @@
 				} else {
 					$w.on('resize.fluidbox'+fb.instanceData.id, resizeFunction);
 				}
+				
+				// close fluidbox on window scroll event
+				$(window).scroll(function(){
+					fb.close();
+				});
 
 				// Reposition
 				$fb.on('reposition.fluidbox', function() {


### PR DESCRIPTION
This commit adds a listener on the window scroll event and closes the fluidbox accordingly. Same behavior as on Medium.