### PR TITLE
Fixed missing devDependencies autoprefixer and cssnano

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,8 @@
     "test": "echo \"Error: no test specified\" && exit 0"
   },
   "devDependencies": {
+    "autoprefixer": "^6.2.3",
+    "cssnano": "^3.4.0",
     "grunt": "^0.4.5",
     "grunt-concurrent": "^2.0.3",
     "grunt-contrib-clean": "^0.6.0",


### PR DESCRIPTION
Fluidbox cannot be built without installing ```autoprefixer``` and ```cssnano```.