### PR TITLE
Fix blurry images in Safari

### DIFF
--- a/src/css/_fluidbox.scss
+++ b/src/css/_fluidbox.scss
@@ -21,9 +21,10 @@ $fluidbox__animation-bg-color: $fluidbox__overlay-bg-color !default;
 	opacity: 0;
 	pointer-events: none;
 	position: fixed;
-	top: 0;
+	/* Negative top and bottom is to fix some Safari cases where image got blurry */
+	top: -100%;
 	left: 0;
-	bottom: 0;
+	bottom: -100%;
 	right: 0;
 	/* Transition time for overlay is halved to ensure that flickering doesn't happen */
 	transition: all $fluidbox__transition-duration ease-in-out;


### PR DESCRIPTION
Will add a not so pretty fix for Safari to correctly render the `.fluidbox__overlay`.

Fixes #168 