### PR TITLE
Use more verbose transition, which works better with autoprefixer

### DIFF
--- a/src/css/_fluidbox.scss
+++ b/src/css/_fluidbox.scss
@@ -47,16 +47,7 @@ $fluidbox__animation-bg-color: $fluidbox__overlay-bg-color !default;
 	background-position: center center;	
 	background-repeat: no-repeat;
 	position: absolute;
-	transition-duration: 0s, $fluidbox__transition-duration;
-	transition-delay: 0s;
-
-	// transition-property manually prefixed
-	// Autoprefixer insists on adding the line:
-	// > transition-property: opacity, transform, -webkit-transform;
-	// ...which will break Fluidbox
-	-webkit-transition-property: opacity, -webkit-transform;	/* autoprefixer: off */
-	transition-property: opacity, -webkit-transform;			/* autoprefixer: off */
-	transition-property: opacity, transform;					/* autoprefixer: off */
+	transition: opacity 0s 0s, transform $fluidbox__transition-duration 0s;
 
 	.fluidbox--opened & {
 		cursor: pointer;
@@ -65,7 +56,7 @@ $fluidbox__animation-bg-color: $fluidbox__overlay-bg-color !default;
 		cursor: zoom-out;
 	}
 	.fluidbox--closed & {
-		transition-delay: $fluidbox__transition-duration, 0s;
+		transition: opacity 0s $fluidbox__transition-duration, transform $fluidbox__transition-duration 0s;
 	}
 }
 .fluidbox__loader {


### PR DESCRIPTION
Hiya!

In our project, autoprefixer has been throwing warnings about incorrect CSS in our dependencies, much to the annoyance of @Gaya (and the rest of the team :stuck_out_tongue:). This PR is part of an effort to fix those.

I have replaced the separate `transition-*:` properties with `transition:`. This way autoprefixer has no problems with prefixing the transition/transform.

I've tested it in Chrome and it works fine, but I can test in other environments if that's needed.